### PR TITLE
Implement ability to record events using the Plausible events API

### DIFF
--- a/src/PlausibleAPI.php
+++ b/src/PlausibleAPI.php
@@ -41,6 +41,16 @@ class PlausibleAPI
         return $this->client;
     }
 
+    /**
+     * Overrides the client created in the constructor with a custom client.
+     *
+     * This is primarily useful for testing purposes.
+     */
+    public function setClient(Client $client): void
+    {
+        $this->client = $client;
+    }
+
     public function getRealtimeVisitors(string $site_id): int
     {
         $response = $this->client->get('v1/stats/realtime/visitors', [
@@ -154,5 +164,56 @@ class PlausibleAPI
         ]);
 
         return json_decode($response->getBody()->getContents(), true)['deleted'];
+    }
+
+    /**
+     * @param string $site_id The domain name of the site in Plausible.
+     * @param string $event_name The name of the event to record. To record a
+     *     page view in Plausible, use the value "pageview".
+     * @param string $url The full URL (including protocol, e.g., "https://")
+     *     where the event was triggered.
+     * @param string $user_agent The raw value of the User-Agent header
+     *     included in the request for this event.
+     * @param string $ip_address The IP address for the client that triggered
+     *     this event. Be careful to use the correct IP address of the client
+     *     where the request originated, which might be provided in the
+     *     X-Forwarded-For (or other) header.
+     * @param string|null $referrer The referrer URL for this event, if available.
+     * @param array<string, scalar|null> | null $properties Optional custom
+     *     properties for the event.
+     * @param array{currency: string, amount: float|string} | null $revenue Optional
+     *     revenue data for the event. This should include the properties
+     *     "currency," which maps to an ISO 4217 currency code, and "amount,"
+     *     which can be a float or a string.
+     *
+     * @return bool
+     */
+    public function recordEvent(
+        string $site_id,
+        string $event_name,
+        string $url,
+        string $user_agent,
+        string $ip_address,
+        ?string $referrer = null,
+        ?array $properties = null,
+        ?array $revenue = null
+    ): bool {
+        $response = $this->client->post('event', [
+            'headers' => [
+                'user-agent' => $user_agent,
+                'x-forwarded-for' => $ip_address,
+                'content-type' => 'application/json',
+            ],
+            'body' => json_encode(array_filter([
+                'domain' => $site_id,
+                'name' => $event_name,
+                'url' => $url,
+                'referrer' => $referrer,
+                'props' => $properties,
+                'revenue' => $revenue,
+            ])),
+        ]);
+
+        return $response->getStatusCode() === 202;
     }
 }

--- a/src/PlausibleAPI.php
+++ b/src/PlausibleAPI.php
@@ -14,8 +14,14 @@ class PlausibleAPI
 {
     protected Client $client;
 
-    public function __construct(string $token, string $base_uri = 'https://plausible.io/api/v1/')
+    public function __construct(string $token, string $base_uri = 'https://plausible.io/api/')
     {
+        // This provides backwards compatibility with the $base_uri in earlier
+        // versions of this library, which assumed a trailing "/v1/" in the path.
+        if (substr($base_uri, -4) === '/v1/' || substr($base_uri, -3) === '/v1') {
+            $base_uri = substr($base_uri, 0, -3);
+        }
+
         $this->client = new Client([
             'base_uri' => $base_uri,
             'headers' => [
@@ -25,9 +31,19 @@ class PlausibleAPI
         ]);
     }
 
+    /**
+     * Returns the HTTP client used to make API requests.
+     *
+     * This is primarily useful for testing purposes.
+     */
+    public function getClient(): Client
+    {
+        return $this->client;
+    }
+
     public function getRealtimeVisitors(string $site_id): int
     {
-        $response = $this->client->get('stats/realtime/visitors', [
+        $response = $this->client->get('v1/stats/realtime/visitors', [
             'query' => [
                 'site_id' => $site_id,
             ],
@@ -38,7 +54,7 @@ class PlausibleAPI
 
     public function getAggregate(string $site_id, array $extras = []): AggregatedMetrics
     {
-        $response = $this->client->get('stats/aggregate', [
+        $response = $this->client->get('v1/stats/aggregate', [
             'query' => array_merge(
                 $extras,
                 [
@@ -52,7 +68,7 @@ class PlausibleAPI
 
     public function getTimeseries(string $site_id, array $extras = []): TimeseriesCollection
     {
-        $response = $this->client->get('stats/timeseries', [
+        $response = $this->client->get('v1/stats/timeseries', [
             'query' => array_merge(
                 $extras,
                 [
@@ -66,7 +82,7 @@ class PlausibleAPI
 
     public function getBreakdown(string $site_id, string $property, array $extras = []): BreakdownCollection
     {
-        $response = $this->client->get('stats/breakdown', [
+        $response = $this->client->get('v1/stats/breakdown', [
             'query' => array_merge(
                 $extras,
                 [
@@ -81,7 +97,7 @@ class PlausibleAPI
 
     public function createWebsite(array $payload): Website
     {
-        $response = $this->client->post('sites', [
+        $response = $this->client->post('v1/sites', [
             'form_params' => $payload,
         ]);
 
@@ -90,7 +106,7 @@ class PlausibleAPI
 
     public function updateWebsite(string $site_id, array $payload): Website
     {
-        $response = $this->client->put('sites/' . urlencode($site_id), [
+        $response = $this->client->put('v1/sites/' . urlencode($site_id), [
             'form_params' => $payload,
         ]);
 
@@ -99,21 +115,21 @@ class PlausibleAPI
 
     public function deleteWebsite(string $site_id): bool
     {
-        $response = $this->client->delete('sites/' . urlencode($site_id));
+        $response = $this->client->delete('v1/sites/' . urlencode($site_id));
 
         return json_decode($response->getBody()->getContents(), true)['deleted'];
     }
 
     public function getWebsite(string $site_id): Website
     {
-        $response = $this->client->get('sites/' . urlencode($site_id));
+        $response = $this->client->get('v1/sites/' . urlencode($site_id));
 
         return Website::fromApiResponse($response->getBody()->getContents());
     }
 
     public function createSharedLink(array $payload): SharedLink
     {
-        $response = $this->client->put('sites/shared-links', [
+        $response = $this->client->put('v1/sites/shared-links', [
             'form_params' => $payload,
         ]);
 
@@ -122,7 +138,7 @@ class PlausibleAPI
 
     public function createGoal(array $payload): Goal
     {
-        $response = $this->client->put('sites/goals', [
+        $response = $this->client->put('v1/sites/goals', [
             'form_params' => $payload,
         ]);
 
@@ -131,7 +147,7 @@ class PlausibleAPI
 
     public function deleteGoal(int $goal_id, string $site_id): bool
     {
-        $response = $this->client->delete('sites/goals/' . urlencode((string) $goal_id), [
+        $response = $this->client->delete('v1/sites/goals/' . urlencode((string) $goal_id), [
             'form_params' => [
                 'site_id' => $site_id,
             ],

--- a/tests/PlausibleAPITest.php
+++ b/tests/PlausibleAPITest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Devarts\PlausiblePHP\Test;
+
+use Devarts\PlausiblePHP\PlausibleAPI;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\UriInterface;
+
+class PlausibleAPITest extends TestCase
+{
+    /**
+     * @testWith ["https://plausible.io/api/", null]
+     *           ["https://plausible.io/api/", "https://plausible.io/api/v1/"]
+     *           ["https://plausible.io/api", "https://plausible.io/api/v1"]
+     *           ["https://example.com/path/to/plausible/", "https://example.com/path/to/plausible/v1/"]
+     *           ["https://example.com/path/to/plausible", "https://example.com/path/to/plausible/v1"]
+     */
+    public function testBaseUri(string $expected_base_uri, ?string $passed_base_uri): void
+    {
+        if ($passed_base_uri !== null) {
+            $plausible = new PlausibleAPI('an_api_token', $passed_base_uri);
+        } else {
+            $plausible = new PlausibleAPI('an_api_token');
+        }
+
+        /** @var UriInterface $baseUri */
+        $baseUri = $plausible->getClient()->getConfig('base_uri');
+
+        $this->assertSame($expected_base_uri, (string) $baseUri);
+    }
+}

--- a/tests/PlausibleAPITest.php
+++ b/tests/PlausibleAPITest.php
@@ -3,7 +3,9 @@
 namespace Devarts\PlausiblePHP\Test;
 
 use Devarts\PlausiblePHP\PlausibleAPI;
+use GuzzleHttp\Client;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
 
 class PlausibleAPITest extends TestCase
@@ -27,5 +29,111 @@ class PlausibleAPITest extends TestCase
         $baseUri = $plausible->getClient()->getConfig('base_uri');
 
         $this->assertSame($expected_base_uri, (string) $baseUri);
+    }
+
+    public function testRecordEvent(): void
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(202);
+
+        $client = $this->createMock(Client::class);
+        $client
+            ->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->equalTo('event'),
+                $this->equalTo([
+                    'headers' => [
+                        'user-agent' => 'MyAgent/3.0',
+                        'x-forwarded-for' => '96.44.96.255',
+                        'content-type' => 'application/json',
+                    ],
+                    'body' => json_encode([
+                        'domain' => 'example.com',
+                        'name' => 'pageview',
+                        'url' => 'https://example.com/path/to/some/page',
+                        'referrer' => 'https://example.com/path/to/another/page',
+                        'props' => [
+                            'logged_in' => false,
+                            'language' => 'en-US',
+                        ],
+                        'revenue' => [
+                            'currency' => 'USD',
+                            'amount' => 315.42,
+                        ],
+                    ])
+                ])
+            )->willReturn($response);
+
+        $plausible = new PlausibleAPI('an_api_token');
+        $plausible->setClient($client);
+
+        $this->assertTrue($plausible->recordEvent(
+            'example.com',
+            'pageview',
+            'https://example.com/path/to/some/page',
+            'MyAgent/3.0',
+            '96.44.96.255',
+            'https://example.com/path/to/another/page',
+            ['logged_in' => false, 'language' => 'en-US'],
+            ['currency' => 'USD', 'amount' => 315.42],
+        ));
+    }
+
+    public function testRecordEventExcludingOptionalValues(): void
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(202);
+
+        $client = $this->createMock(Client::class);
+        $client
+            ->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->equalTo('event'),
+                $this->equalTo([
+                    'headers' => [
+                        'user-agent' => 'MyOtherAgent/3.0',
+                        'x-forwarded-for' => '77.91.71.175',
+                        'content-type' => 'application/json',
+                    ],
+                    'body' => json_encode([
+                        'domain' => 'subdomain.example.com',
+                        'name' => 'custom.event',
+                        'url' => 'https://example.com/path/to/some/page',
+                    ])
+                ])
+            )->willReturn($response);
+
+        $plausible = new PlausibleAPI('an_api_token');
+        $plausible->setClient($client);
+
+        $this->assertTrue($plausible->recordEvent(
+            'subdomain.example.com',
+            'custom.event',
+            'https://example.com/path/to/some/page',
+            'MyOtherAgent/3.0',
+            '77.91.71.175',
+        ));
+    }
+
+    public function testRecordEventReturnsFalseWhenUnsuccessful(): void
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(400);
+
+        $client = $this->createStub(Client::class);
+        $client->method('post')->willReturn($response);
+
+        $plausible = new PlausibleAPI('an_api_token');
+        $plausible->setClient($client);
+
+        $this->assertFalse($plausible->recordEvent(
+            'subdomain2.example.com',
+            'something-happened',
+            'https://example.com/path/to/page',
+            'MyAgent/2.0',
+            '4.243.144.9',
+        ));
     }
 }


### PR DESCRIPTION
This pull request provides a `PlausibleAPI::recordEvent()` method that allows implementations to send events to Plausible from server-side code, using the [Plausible Events API](https://plausible.io/docs/events-api).

The method signature is, as follows:

```php
public function recordEvent(
    string $site_id,
    string $event_name,
    string $url,
    string $user_agent,
    string $ip_address,
    ?string $referrer = null,
    ?array $properties = null,
    ?array $revenue = null
): bool;
```

The arguments are:

| Argument | Description |
| -------- | ----------- |
| `$site_id` | The domain name of the site in Plausible. |
| `$event_name` | The name of the event to record. To record a page view in Plausible, use the value "pageview". |
| `$url` | The full URL (including protocol, e.g., "https://") where the event was triggered. |
| `$user_agent` | The raw value of the `User-Agent` header included in the request for this event. |
| `$ip_address` | The IP address for the client that triggered this event. Be careful to use the correct IP address of the client where the request originated, which might be provided in the `X-Forwarded-For` (or other) header. |
| `$referrer` | *(optional)* The referrer URL for this event, if available. |
| `$properties` | *(optional)* Custom properties for the event. |
| `$revenue` | *(optional)* Revenue data for the event. This should include the properties `currency`, which maps to an ISO 4217 currency code, and `amount`, which can be a float or a string. |

> [!NOTE]
> In order to support the events API, I moved the "/v1/" path out of the default `$base_uri` value, which means any uses of this library that provide a custom `$base_uri` would need to update their URI accordingly. I have mitigated this backwards compatibility break by checking for the presence of "/v1/" and removing it automatically.