### PR TITLE
Add missing name property definition to `BreakdownItem`

### DIFF
--- a/src/Response/BreakdownItem.php
+++ b/src/Response/BreakdownItem.php
@@ -3,6 +3,7 @@
 namespace Devarts\PlausiblePHP\Response;
 
 /**
+ * @property string $name
  * @property string $goal
  * @property string $page
  * @property string $entry_page


### PR DESCRIPTION
Unintentionally dropped in https://github.com/devarts/plausible-php/pull/8